### PR TITLE
Policy for releasing Thinreports

### DIFF
--- a/.github/ISSUE_TEMPLATE/releasing-new-version.md
+++ b/.github/ISSUE_TEMPLATE/releasing-new-version.md
@@ -7,26 +7,44 @@ assignees: ''
 
 ---
 
-## Why
+<!--
+If necessary, describe the purpose, reason, and background for this release here.
+-->
 
-<Purpose, reason for the release>
+## Plans
 
-## What
+### What to release
 
 - [ ] Editor
 - [ ] Generator
 
-## When
+### When to release
 
-<Release data>
+<!-- Release data -->
 
-## Tasks
+## Steps
 
-- [ ] Prepare releases
-   - Editor: <url for the pull request>
-   - Generator: <url for the pull request>
-- [ ] Publish releases
-   - Editor: <url for the release>
-   - Generator: <url for rubygems>
-- [ ] Announce the release
-   - <url for the pull request>
+<!--
+If this release includes only one of Editor or Generator, delete the checklist for the one not released.
+-->
+
+Refer to the followings for each steps:
+
+- [Releasing Editor](https://github.com/thinreports/thinreports-editor#releasing-editor)
+- [Releasing Generator](https://github.com/thinreports/thinreports-generator#releasing-generator)
+- [Adding News](https://github.com/thinreports/thinreports.org#adding-news)
+
+### 1. Prepare and review releases
+
+- [ ] Editor: <!-- put url for pull request here -->
+- [ ] Geneartor: <!-- put url for pull request here -->
+
+### 2. Publish releases
+
+- [ ] Editor: <!-- put url for the published release here -->
+- [ ] Generator: <!-- put url for the published rubygem here -->
+
+### 3. Post the announcement to the official site
+
+- [ ] Create the announcement: <!-- put url for the pull request here -->
+- [ ] Post the announcement: <!-- put url for the posted announcement here -->

--- a/RELEASING_THINREPORTS.md
+++ b/RELEASING_THINREPORTS.md
@@ -1,0 +1,12 @@
+# Releasing Thinreports
+
+この文書ではThinreportsの新しいバージョンをリリースする手順を説明します。
+
+## Issueを作成してリリースの方針を決める
+
+まず、"Releasing new version"を選択してリリースイシューを作成します。リリースする内容や目的、日程などの計画を記載し、その計画について少なくとも一人以上のメンバーに確認します。
+https://github.com/thinreports/thinreports/issues/new/choose
+
+## リリースIssueの手順に従ってリリースする
+
+リリースの手順はリリースイシューに記載されています。その手順に従ってリリースしてください。

--- a/RELEASING_THINREPORTS.md
+++ b/RELEASING_THINREPORTS.md
@@ -1,12 +1,14 @@
 # Releasing Thinreports
 
-この文書ではThinreportsの新しいバージョンをリリースする手順を説明します。
+This document describes the steps to release a new version of Thinreports.
 
-## Issueを作成してリリースの方針を決める
+## Create an issue and plan a release
 
-まず、"Releasing new version"を選択してリリースイシューを作成します。リリースする内容や目的、日程などの計画を記載し、その計画について少なくとも一人以上のメンバーに確認します。
+First, select "Releasing new version" to create a Release Issue.
+Describe the plan such as the contents to be released, the purpose, the schedule, etc., and confirm it with at least one or more members.
+
 https://github.com/thinreports/thinreports/issues/new/choose
 
-## リリースIssueの手順に従ってリリースする
+## Release according to the Release Issue
 
-リリースの手順はリリースイシューに記載されています。その手順に従ってリリースしてください。
+The release steps is described in the Release Issue. Follow that steps to release.


### PR DESCRIPTION
## Overview

Based on the release steps of v0.11.0, I created a document about releasing Thinreports.

## Details

- Create issue template for releasing
- Create release policy

## About issue template

The issue template is based on [Issue #10 Release v0.11.0](https://github.com/thinreports/thinreports/issues/10). I changed the content of #10 to the "Releasing new version" issue style, so please also refer to this for your review.

## About release policy

The commit aba7201 is written in Japanese, so you may want to check this content.
