### PR TITLE
ニュースを GitHub Discussions で管理することとし、README にリンクを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Section Format is a new template format that allows you to define a layout by di
 - [Quick Start](getting-started/section-format.md#quick-start)
 - [Examples](getting-started/section-format.md#examples)
 
+## News
+
+Please see [Announcements at Thinreports Discussions](https://github.com/thinreports/thinreports/discussions/categories/announcement).
+
 ## Support
 
 If you have questions about Thinreports, please feel free to ask them in the our [GitHub Discussions](https://github.com/thinreports/thinreports/discussions) forum.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>
-    <img alt="Thinreports" src="thinreports.png" width="80"/>
+    <img alt="Thinreports" src="https://raw.githubusercontent.com/thinreports/thinreports/main/thinreports.png" width="80"/>
     <br/>
     Thinreports
   </h1>
@@ -25,8 +25,8 @@ The basic functionality of both formats is the same, but Section Format is more 
 
 Basic Format is a traditional and stable format in which shapes, text, etc. are placed on a fixed size canvas and a PDF is generated.
 
-- [Installation](getting-started/basic-format.md#installation)
-- [Quick Start](getting-started/basic-format.md#quick-start)
+- [Installation](https://github.com/thinreports/thinreports/blob/main/getting-started/basic-format.md#installation)
+- [Quick Start](https://github.com/thinreports/thinreports/blob/main/getting-started/basic-format.md#quick-start)
 - [API Reference](https://github.com/thinreports/thinreports-generator/blob/master/README.md#quick-reference)
 - [Examples](https://github.com/thinreports/thinreports-examples)
 - [Rails Application Example](https://github.com/thinreports/thinreports-rails-example)
@@ -37,10 +37,10 @@ Basic Format is a traditional and stable format in which shapes, text, etc. are 
 
 Section Format is a new template format that allows you to define a layout by dividing it into units called sections, and then freely combine them to generate a PDF.
 
-- [Features](getting-started/section-format.md#features)
-- [Installation](getting-started/section-format.md#installation)
-- [Quick Start](getting-started/section-format.md#quick-start)
-- [Examples](getting-started/section-format.md#examples)
+- [Features](https://github.com/thinreports/thinreports/blob/main/getting-started/section-format.md#features)
+- [Installation](https://github.com/thinreports/thinreports/blob/main/getting-started/section-format.md#installation)
+- [Quick Start](https://github.com/thinreports/thinreports/blob/main/getting-started/section-format.md#quick-start)
+- [Examples](https://github.com/thinreports/thinreports/blob/main/getting-started/section-format.md#examples)
 
 ## News
 


### PR DESCRIPTION
件名の通り、ニュースの管理を次のようにします。

- 今後のすべてのお知らせは GitHub Discussions の Announcements に集約する
- README でそのことを説明する

Announcements はメンテナーのみ投稿できます。
![image](https://user-images.githubusercontent.com/739339/141610162-5846ac68-e20e-46c1-aa6e-c0eb392bef81.png)

また、https://github.com/thinreports/thinreports.github.io/pull/2 でのサイトリニューアルのための準備として以下を行います。

- この README を thinreports.org のトップページにするにために、各リンクを絶対URLに変更


なお、thinreports.org の既存のニュースは、https://github.com/thinreports/thinreports.github.io/pull/2 によるサイトコンテンツのリニューアルに伴って削除します。