### PR TITLE
コントリビューティングガイドを CONTRIBUTING.md へ移行する

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+## How to contribute to Thinreports
+
+Thinreports is, and always will be, provided free of charge. Any activity of Thinreports is voluntary activity by member of Thinreports.org community. If you use Thinreports and like it, please consider the contribution by all means.
+
+### Contributing to Thinreports libraries
+
+If you have a bug or suggestions on Thinreports library such as [Thinreports Editor](https://github.com/thinreports/thinreports-editor) and [Thinreports Generator](https://github.com/thinreports/thinreports-generator), you can contribute in the following ways:
+
+- Report bugs, post your suggestions
+- Send your patchs by Pull Request
+- Add/Improve the Editor's locale in your language
+
+### Contributing to join our discussion group
+
+We have [the official discussion group on GitHub Discussions](https://github.com/thinreports/thinreports/discussions).
+
+- Post your Tips or Techniques of Thinreports
+- Post your questions about Thinreports
+- Answer the questions
+
+### Contributing to Thinreports Documentation
+
+Thinreports has the following documentations and examples:
+
+- [thinreports/thinreports](https://github.com/thinreports/thinreports)
+- [thinreports/thinreports-examples](https://github.com/thinreports/thinreports-examples)
+- [thinreports/thinreports-rails-example](https://github.com/thinreports/thinreports-rails-example)
+
+You can contribute in the following ways:
+
+- Report mistakes, post your suggestions
+- Improve quality of English grammer

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you have questions about Thinreports, please feel free to ask them in [the ou
 
 ## Contributing
 
-Please see [Contributing to Thinreports](https://github.com/thinreports/thinreports/wiki/How-to%3A-Contributing-to-Thinreports).
+Please see [How to contribute to Thinreports](https://github.com/thinreports/thinreports/blob/main/CONTRIBUTING.md).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Basic Format is a traditional and stable format in which shapes, text, etc. are 
 
 - [Installation](https://github.com/thinreports/thinreports/blob/main/getting-started/basic-format.md#installation)
 - [Quick Start](https://github.com/thinreports/thinreports/blob/main/getting-started/basic-format.md#quick-start)
-- [API Reference](https://github.com/thinreports/thinreports-generator/blob/master/README.md#usage)
+- [API Reference](https://github.com/thinreports/thinreports-generator/blob/main/README.md#usage)
 - [Examples](https://github.com/thinreports/thinreports-examples)
 - [Rails Application Example](https://github.com/thinreports/thinreports-rails-example)
 


### PR DESCRIPTION
This PR fixes #30.

## 相談

マージするタイミングで wiki 全体も閉じます。ただし、 [tlf ファイルの仕様 (spreadsheet) のリンクのみ](https://github.com/thinreports/thinreports/wiki/Spec%3A-Layout-File%3A-Format) 、別途適切な場所に移動しときます。それ以外の wiki の情報はメンテもされていないし使っていないので削除しても問題ないかと。